### PR TITLE
Add SAF folder selection for general JSON export on Android; revert therapy export to share sheet

### DIFF
--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -495,6 +495,31 @@ export default function SettingsScreen() {
         : exportRange === "full"
         ? `moodinator-export-full-${formatDateSlug(new Date())}.json`
         : `moodinator-export-${exportRange}-${formatDateSlug(new Date())}.json`;
+
+    if (Platform.OS === "android") {
+      const permissions =
+        await FileSystem.StorageAccessFramework.requestDirectoryPermissionsAsync();
+      if (!permissions.granted) {
+        Alert.alert(
+          "Permission Denied",
+          "Please grant folder access to save the export."
+        );
+        return;
+      }
+
+      const fileUri =
+        await FileSystem.StorageAccessFramework.createFileAsync(
+          permissions.directoryUri,
+          fileName,
+          "application/json"
+        );
+      await FileSystem.writeAsStringAsync(fileUri, jsonData, {
+        encoding: FileSystem.EncodingType.UTF8,
+      });
+      Alert.alert("Export Saved", "Your export was saved to the selected folder.");
+      return;
+    }
+
     const fileUri = `${FileSystem.cacheDirectory}${fileName}`;
     await FileSystem.writeAsStringAsync(fileUri, jsonData, {
       encoding: FileSystem.EncodingType.UTF8,

--- a/src/app/therapy-export.tsx
+++ b/src/app/therapy-export.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
-  Platform,
   Pressable,
   SafeAreaView,
   ScrollView,


### PR DESCRIPTION
### Motivation
- Let users choose a folder to save general JSON exports on Android using the Storage Access Framework instead of forcing the share sheet or temporary cache.
- Preserve the therapy CSV export behavior so it continues to use the share sheet and cache-based temporary file flow.
- Provide clear alerts when folder permission is denied and when an export is successfully saved to the selected folder.

### Description
- Added an Android-specific flow in `shareJsonData` (`src/app/(tabs)/settings.tsx`) that calls `FileSystem.StorageAccessFramework.requestDirectoryPermissionsAsync()`, creates the JSON file with `createFileAsync`, writes it with `writeAsStringAsync`, and shows success/denied alerts.
- Kept the existing non-Android path that writes to `FileSystem.cacheDirectory` and uses `Sharing.shareAsync` with a clipboard fallback and cache cleanup.
- Reverted the earlier Android-specific changes in `src/app/therapy-export.tsx`, removed the unused `Platform` import, and restored the therapy export to use the share sheet plus the existing clipboard fallback and file cleanup.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbeb77dd48327939c5cfe9ddfa882)